### PR TITLE
Remove configuration dependency

### DIFF
--- a/Examples/Multi-Publisher/Multi-Publisher.csproj
+++ b/Examples/Multi-Publisher/Multi-Publisher.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="microsoft.extensions.Configuration.Json" Version="2.2.0" />
+    <PackageReference Include="microsoft.extensions.DependencyInjection" Version="2.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\SimpleRabbit.NetCore\SimpleRabbit.NetCore.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/Examples/Multi-Publisher/NamedService.cs
+++ b/Examples/Multi-Publisher/NamedService.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace Publisher
+{
+    
+    public class NamedService<T>
+    {
+        public string Name { get; set;}
+        public T Service { get;set; }
+    }
+}

--- a/Examples/Multi-Publisher/Program.cs
+++ b/Examples/Multi-Publisher/Program.cs
@@ -17,30 +17,31 @@ namespace Publisher
 
             
 
-            PublishService PublisherFactory(IServiceProvider service, string name,IConfigurationSection section)
+            NamedService<IPublishService> PublisherFactory(IServiceProvider service, string name,IConfigurationSection section)
             {
-                var p = new PublishService(section.Get<RabbitConfiguration>());
-                p.ConfigurationName = name;
+                var p = new NamedService<IPublishService>();
+                p.Name = name;
+                p.Service = new PublishService(section.Get<RabbitConfiguration>());
                 return p;
             }
 
             var services = new ServiceCollection();
 
             services
-                .AddSingleton<IPublishService>(c => PublisherFactory(c, "Configuration1", configuration.GetSection("RabbitConfigurations:Configuration1")))
-                .AddSingleton<IPublishService>(c => PublisherFactory(c, "Configuration2", configuration.GetSection("RabbitConfigurations:Configuration2")))
-                .AddSingleton<IPublishService>(c => PublisherFactory(c, "Configuration3", configuration.GetSection("RabbitConfigurations:Configuration3")))
-                .AddTransient(c => c.GetServices<IPublishService>().ToList());
+                .AddSingleton(c => PublisherFactory(c, "Configuration1", configuration.GetSection("RabbitConfigurations:Configuration1")))
+                .AddSingleton(c => PublisherFactory(c, "Configuration2", configuration.GetSection("RabbitConfigurations:Configuration2")))
+                .AddSingleton(c => PublisherFactory(c, "Configuration3", configuration.GetSection("RabbitConfigurations:Configuration3")))
+                .AddTransient(c => c.GetServices<NamedService<IPublishService>>().ToList());
 
             var provider = services.BuildServiceProvider();
 
-            var publisher = provider.GetRequiredService<List<IPublishService>>().FirstOrDefault(p => p.ConfigurationName.Equals("Configuration1"));
+            var publisher = provider.GetRequiredService<List<NamedService<IPublishService>>>().FirstOrDefault(p => p.Name.Equals("Configuration1"));
 
             Console.Write($"Publishing: ");
-            publisher.Publish("ExchangeName", body: $"This is a test message - {DateTime.Now.ToLongDateString()}");
+            publisher.Service.Publish("MyFeed.Api", body: $"This is a test message - {DateTime.Now.ToLongDateString()}");
             Console.WriteLine("done");
 
-            publisher.Close();
+            publisher.Service.Close();
         }
     }
 }

--- a/Examples/Multi-Publisher/Program.cs
+++ b/Examples/Multi-Publisher/Program.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using SimpleRabbit.NetCore;
+
+namespace Publisher
+{
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json", true)
+                .Build();
+
+            
+
+            PublishService PublisherFactory(IServiceProvider service, string name,IConfigurationSection section)
+            {
+                var p = new PublishService(section.Get<RabbitConfiguration>());
+                p.ConfigurationName = name;
+                return p;
+            }
+
+            var services = new ServiceCollection();
+
+            services
+                .AddSingleton<IPublishService>(c => PublisherFactory(c, "Configuration1", configuration.GetSection("RabbitConfigurations:Configuration1")))
+                .AddSingleton<IPublishService>(c => PublisherFactory(c, "Configuration2", configuration.GetSection("RabbitConfigurations:Configuration2")))
+                .AddTransient(c => c.GetServices<IPublishService>().ToList());
+
+            var provider = services.BuildServiceProvider();
+
+            var publisher = provider.GetRequiredService<List<IPublishService>>().FirstOrDefault(p => p.ConfigurationName.Equals("Configuration1"));
+
+            Console.Write($"Publishing: ");
+            publisher.Publish("ExchangeName", body: $"This is a test message - {DateTime.Now.ToLongDateString()}");
+            Console.WriteLine("done");
+
+            publisher.Close();
+        }
+    }
+}

--- a/Examples/Multi-Publisher/Program.cs
+++ b/Examples/Multi-Publisher/Program.cs
@@ -38,7 +38,7 @@ namespace Publisher
             var publisher = provider.GetRequiredService<List<NamedService<IPublishService>>>().FirstOrDefault(p => p.Name.Equals("Configuration1"));
 
             Console.Write($"Publishing: ");
-            publisher.Service.Publish("MyFeed.Api", body: $"This is a test message - {DateTime.Now.ToLongDateString()}");
+            publisher.Service.Publish("Example", body: $"This is a test message - {DateTime.Now.ToLongDateString()}");
             Console.WriteLine("done");
 
             publisher.Service.Close();

--- a/Examples/Multi-Publisher/Program.cs
+++ b/Examples/Multi-Publisher/Program.cs
@@ -29,6 +29,7 @@ namespace Publisher
             services
                 .AddSingleton<IPublishService>(c => PublisherFactory(c, "Configuration1", configuration.GetSection("RabbitConfigurations:Configuration1")))
                 .AddSingleton<IPublishService>(c => PublisherFactory(c, "Configuration2", configuration.GetSection("RabbitConfigurations:Configuration2")))
+                .AddSingleton<IPublishService>(c => PublisherFactory(c, "Configuration3", configuration.GetSection("RabbitConfigurations:Configuration3")))
                 .AddTransient(c => c.GetServices<IPublishService>().ToList());
 
             var provider = services.BuildServiceProvider();

--- a/Examples/Multi-Publisher/appsettings.json
+++ b/Examples/Multi-Publisher/appsettings.json
@@ -1,8 +1,12 @@
 {
   "RabbitConfigurations": {
     "Configuration1": {
-      "Uri": "amqp://guest:guest@localhost/",
-      "Name": "publisher 1"
+      "Username": "guest",
+      "Password": "guest",
+      "Name": "publisher 1",
+      "Hostnames": [
+        "localhost"
+      ]
     },
     "Configuration2": {
       "Username": "guest",
@@ -10,13 +14,16 @@
       "Name": "publisher 2",
       "Hostnames": [
         "localhost"
-      ]
+      ],
+      "VirtualHost": "/"
     },
     "Configuration3": {
-      "Uri": "amqp://localhost/",
-      "Name": "publisher 3",
       "Username": "guest",
-      "Password": "guest"
+      "Password": "guest",
+      "Name": "publisher 3",
+      "Hostnames": [
+        "localhost"
+      ]
     }
   },
   "Logging": {

--- a/Examples/Multi-Publisher/appsettings.json
+++ b/Examples/Multi-Publisher/appsettings.json
@@ -1,14 +1,22 @@
 {
   "RabbitConfigurations": {
     "Configuration1": {
-      "Uri": "amqp://guest:guest@localhost/"
+      "Uri": "amqp://guest:guest@localhost/",
+      "Name": "publisher 1"
     },
     "Configuration2": {
       "Username": "guest",
       "Password": "guest",
+      "Name": "publisher 2",
       "Hostnames": [
         "localhost"
       ]
+    },
+    "Configuration3": {
+      "Uri": "amqp://localhost/",
+      "Name": "publisher 3",
+      "Username": "guest",
+      "Password": "guest"
     }
   },
   "Logging": {

--- a/Examples/Multi-Publisher/appsettings.json
+++ b/Examples/Multi-Publisher/appsettings.json
@@ -1,0 +1,22 @@
+{
+  "RabbitConfigurations": {
+    "Configuration1": {
+      "Uri": "amqp://guest:guest@localhost/"
+    },
+    "Configuration2": {
+      "Username": "guest",
+      "Password": "guest",
+      "Hostnames": [
+        "localhost"
+      ]
+    }
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Trace"
+    },
+    "Console": {
+      "IncludeScopes": true
+    }
+  } 
+}

--- a/Examples/Publisher/Program.cs
+++ b/Examples/Publisher/Program.cs
@@ -15,8 +15,7 @@ namespace Publisher
                 .Build();
 
             var provider = new ServiceCollection()
-                .Configure<RabbitConfiguration>(configuration.GetSection("RabbitConfiguration"))
-                .AddSingleton(c => c.GetService<IOptions<RabbitConfiguration>>()?.Value)
+                .AddRabbitConfiguration(configuration.GetSection("RabbitConfiguration"))
                 .AddPublisherServices()
                 .BuildServiceProvider();
 

--- a/Examples/Publisher/Program.cs
+++ b/Examples/Publisher/Program.cs
@@ -25,7 +25,7 @@ namespace Publisher
             for (var index = 0; index < 1000; index++)
             {
                 Console.Write($"Publishing {index} : ");
-                publisher.Publish("Example", body: $"This is a test message - {index} - {DateTime.Now.ToLongDateString()}");
+                publisher.Publish("MyFeed.Api", body: $"This is a test message - {index} - {DateTime.Now.ToLongDateString()}");
                 Console.WriteLine("done");
             }
 

--- a/Examples/Publisher/appsettings.json
+++ b/Examples/Publisher/appsettings.json
@@ -1,6 +1,11 @@
 {
   "RabbitConfiguration": {
-    "Uri": "amqp://guest:guest@localhost/"
+    "Username": "guest",
+    "Password": "guest",
+    "Name": "publisher 2",
+    "Hostnames": [
+      "localhost"
+    ]
   },
   "Logging": {
     "LogLevel": {

--- a/Examples/Subscriber.Service/Program.cs
+++ b/Examples/Subscriber.Service/Program.cs
@@ -29,10 +29,9 @@ namespace Subscriber.Service
                         services
                             .AddSingleton<ILoggerFactory, LoggerFactory>()
                             .AddSingleton<ILogger>(ctx => ctx.GetService<ILogger<HostBuilder>>())
-                            .AddSubscriberServices()
-                            .Configure<RabbitConfiguration>(context.Configuration.GetSection("RabbitConfiguration"))
-                            .Configure<List<SubscriberConfiguration>>(context.Configuration.GetSection("Subscribers"))
-                            .AddSingleton(c => c.GetService<IOptions<RabbitConfiguration>>()?.Value)
+                            .AddSubscriberServices(context.Configuration)
+                            .AddRabbitConfiguration(context.Configuration)
+                            .AddSubscriberConfiguration(context.Configuration.GetSection("Subscribers"))
                             .AddSingleton<IMessageHandler, MessageProcessor>();
                     })
                     .ConfigureLogging((hostingContext, logging) =>

--- a/Examples/Subscriber.Service/Program.cs
+++ b/Examples/Subscriber.Service/Program.cs
@@ -29,8 +29,8 @@ namespace Subscriber.Service
                         services
                             .AddSingleton<ILoggerFactory, LoggerFactory>()
                             .AddSingleton<ILogger>(ctx => ctx.GetService<ILogger<HostBuilder>>())
-                            .AddSubscriberServices(context.Configuration)
-                            .AddRabbitConfiguration(context.Configuration)
+                            .AddSubscriberServices()
+                            .AddRabbitConfiguration(context.Configuration.GetSection("RabbitConfiguration"))
                             .AddSubscriberConfiguration(context.Configuration.GetSection("Subscribers"))
                             .AddSingleton<IMessageHandler, MessageProcessor>();
                     })

--- a/Examples/Subscriber.Service/appsettings.json
+++ b/Examples/Subscriber.Service/appsettings.json
@@ -1,12 +1,17 @@
 {
   "RabbitConfiguration": {
-    "Uri": "amqp://guest:guest@localhost/"
+    "Username": "guest",
+    "Password": "guest",
+    "Name": "appName",
+    "Hostnames": [
+      "localhost"
+    ]
   },
   "Subscribers": [
     {
-      "QueueName": "ExampleQueue",
+      "QueueName": "robin-test",
       "ConsumerTag": "Example.Queue.DISPATCH",
-      "Prefetch": 10
+      "PrefetchCount": 10
     }
   ],
   "Logging": {

--- a/Examples/Subscriber.Service/appsettings.json
+++ b/Examples/Subscriber.Service/appsettings.json
@@ -2,9 +2,13 @@
   "RabbitConfiguration": {
     "Uri": "amqp://guest:guest@localhost/"
   },
-    "Subscribers": [
-        { "QueueName": "ExampleQueue", "ConsumerTag": "Example.Queue.DISPATCH", "Prefetch": 10 }
-    ],
+  "Subscribers": [
+    {
+      "QueueName": "ExampleQueue",
+      "ConsumerTag": "Example.Queue.DISPATCH",
+      "Prefetch": 10
+    }
+  ],
   "Logging": {
     "LogLevel": {
       "Default": "Trace"

--- a/Examples/Subscriber.Service/appsettings.json
+++ b/Examples/Subscriber.Service/appsettings.json
@@ -9,7 +9,7 @@
   },
   "Subscribers": [
     {
-      "QueueName": "robin-test",
+      "QueueName": "example",
       "ConsumerTag": "Example.Queue.DISPATCH",
       "PrefetchCount": 10
     }

--- a/SimpleRabbit.NetCore.Service/ServiceCollectionExtension.cs
+++ b/SimpleRabbit.NetCore.Service/ServiceCollectionExtension.cs
@@ -1,6 +1,8 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
+using System.Collections.Generic;
 
 namespace SimpleRabbit.NetCore.Service
 {
@@ -12,7 +14,6 @@ namespace SimpleRabbit.NetCore.Service
                 .AddSingleton<IHostedService, SubscriberService>()
                 .AddTransient<IQueueService, QueueService>();
         }
-
         public static IServiceCollection AddSubscriberConfiguration(this IServiceCollection services, IConfigurationSection config)
         {
             return services

--- a/SimpleRabbit.NetCore.Service/ServiceCollectionExtension.cs
+++ b/SimpleRabbit.NetCore.Service/ServiceCollectionExtension.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 
 namespace SimpleRabbit.NetCore.Service
 {
@@ -10,6 +11,16 @@ namespace SimpleRabbit.NetCore.Service
             return services
                 .AddSingleton<IHostedService, SubscriberService>()
                 .AddTransient<IQueueService, QueueService>();
+        }
+
+        public static IServiceCollection AddSubscriberConfiguration(this IServiceCollection services, IConfigurationSection config)
+        {
+            return services
+                .Configure<List<SubscriberConfiguration>>(config)
+                .AddSingleton((provider) =>
+                {
+                    return provider.GetService<IOptions<List<SubscriberConfiguration>>>().Value;
+                }); ;
         }
     }
 }

--- a/SimpleRabbit.NetCore.Service/SubscriberService.cs
+++ b/SimpleRabbit.NetCore.Service/SubscriberService.cs
@@ -16,11 +16,11 @@ namespace SimpleRabbit.NetCore.Service
         private readonly IServiceProvider _provider;
         private readonly IList<SubscriberConfiguration> _subscribers;
 
-        public SubscriberService(ILogger<SubscriberService> logger, IOptions<List<SubscriberConfiguration>> options, IServiceProvider provider)
+        public SubscriberService(ILogger<SubscriberService> logger, List<SubscriberConfiguration> options, IServiceProvider provider)
         {
             _logger = logger;
             _provider = provider;
-            _subscribers = options.Value;
+            _subscribers = options;
         }
 
         private readonly List<IQueueService> _queueServices = new List<IQueueService>();

--- a/SimpleRabbit.NetCore.sln
+++ b/SimpleRabbit.NetCore.sln
@@ -13,6 +13,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Publisher", "Examples\Publi
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{AA718BB1-A244-4FAC-9A32-343DE6BFF318}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Multi-Publisher", "Examples\Multi-Publisher\Multi-Publisher.csproj", "{33C9840B-09D8-4B0F-B1EC-444E8252ED83}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -35,6 +37,10 @@ Global
 		{93B7A899-A58B-410A-A1C6-D8A90A9B7856}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{93B7A899-A58B-410A-A1C6-D8A90A9B7856}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{93B7A899-A58B-410A-A1C6-D8A90A9B7856}.Release|Any CPU.Build.0 = Release|Any CPU
+		{33C9840B-09D8-4B0F-B1EC-444E8252ED83}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{33C9840B-09D8-4B0F-B1EC-444E8252ED83}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{33C9840B-09D8-4B0F-B1EC-444E8252ED83}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{33C9840B-09D8-4B0F-B1EC-444E8252ED83}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -42,6 +48,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{F2F2F0DC-C986-4AC9-9E6D-E446B80F952C} = {AA718BB1-A244-4FAC-9A32-343DE6BFF318}
 		{93B7A899-A58B-410A-A1C6-D8A90A9B7856} = {AA718BB1-A244-4FAC-9A32-343DE6BFF318}
+		{33C9840B-09D8-4B0F-B1EC-444E8252ED83} = {AA718BB1-A244-4FAC-9A32-343DE6BFF318}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {325060B1-CB28-4224-9CD9-0DA36C124D9D}

--- a/SimpleRabbit.NetCore/Model/RabbitConfiguration.cs
+++ b/SimpleRabbit.NetCore/Model/RabbitConfiguration.cs
@@ -5,7 +5,9 @@ namespace SimpleRabbit.NetCore
     public class RabbitConfiguration
     {
         public List<string> Hostnames { get; set; }
-        
+        /// <summary>
+        /// Name of the connection to RabbitMQ
+        /// </summary>
         public string Name { get; set; }
         public string Username { get; set; }
         public string Password { get; set; }

--- a/SimpleRabbit.NetCore/Service/BasicRabbitService.cs
+++ b/SimpleRabbit.NetCore/Service/BasicRabbitService.cs
@@ -46,7 +46,7 @@ namespace SimpleRabbit.NetCore
                 {
                     UserName = _config.Username,
                     Password = _config.Password,
-                    VirtualHost = _config.VirtualHost ?? ConnectionFactory.DefaultVHost,
+                    VirtualHost = string.IsNullOrWhiteSpace(_config.VirtualHost) ? ConnectionFactory.DefaultVHost : _config.VirtualHost,
                     AutomaticRecoveryEnabled = true,
                     NetworkRecoveryInterval = TimeSpan.FromSeconds(10),
                     TopologyRecoveryEnabled = true,

--- a/SimpleRabbit.NetCore/Service/BasicRabbitService.cs
+++ b/SimpleRabbit.NetCore/Service/BasicRabbitService.cs
@@ -31,10 +31,9 @@ namespace SimpleRabbit.NetCore
 
                 if (string.IsNullOrWhiteSpace(_config.Username) || string.IsNullOrWhiteSpace(_config.Password))
                 {
-                    throw new InvalidCredentialException("Username or password is missing");
+                    throw new InvalidCredentialException("Rabbit Configuration: Username or Password is missing");
                 }
 
-                /// factory instaniation logic.
                 if (_config.Hostnames == null || !_config.Hostnames.Any())
                 {
                     throw new ArgumentNullException(nameof(_config.Hostnames), "Rabbit Configuration: No Hostnames provided");

--- a/SimpleRabbit.NetCore/Service/BasicRabbitService.cs
+++ b/SimpleRabbit.NetCore/Service/BasicRabbitService.cs
@@ -34,7 +34,7 @@ namespace SimpleRabbit.NetCore
                     throw new ArgumentException("Rabbit Configuration: No Uri or Hostnames provided");
                 }
 
-                if (_config.Uri?.UserInfo == null || (string.IsNullOrWhiteSpace(_config.Username) && string.IsNullOrWhiteSpace(_config.Password)))
+                if (string.IsNullOrWhiteSpace(_config.Uri?.UserInfo) && (string.IsNullOrWhiteSpace(_config.Username) || string.IsNullOrWhiteSpace(_config.Password)))
                 {
                     throw new InvalidCredentialException("Username or password is missing");
                 }
@@ -57,13 +57,18 @@ namespace SimpleRabbit.NetCore
                 _factory = new ConnectionFactory
                 {
                     Uri = uri,
-                    UserName = _config.Username,
-                    Password = _config.Password,
                     AutomaticRecoveryEnabled = true,
                     NetworkRecoveryInterval = TimeSpan.FromSeconds(10),
                     TopologyRecoveryEnabled = true,
                     RequestedHeartbeat = 5
                 };
+
+                // If user info is in uri, don't override them with username password.
+                if (string.IsNullOrWhiteSpace(_config.Uri?.UserInfo))
+                {
+                    _factory.UserName = _config.Username;
+                    _factory.Password = _config.Password;
+                }
 
                 return _factory;
             }

--- a/SimpleRabbit.NetCore/Service/ServiceCollectionExtension.cs
+++ b/SimpleRabbit.NetCore/Service/ServiceCollectionExtension.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace SimpleRabbit.NetCore
 {
@@ -8,6 +10,12 @@ namespace SimpleRabbit.NetCore
         {
             return services
                 .AddTransient<IPublishService, PublishService>();
+        }
+        public static IServiceCollection AddRabbitConfiguration(this IServiceCollection services, IConfigurationSection config)
+        {
+            return services
+                .Configure<RabbitConfiguration>(config)
+                .AddSingleton(c => c.GetService<IOptions<RabbitConfiguration>>()?.Value);
         }
     }
 }

--- a/SimpleRabbit.NetCore/SimpleRabbit.NetCore.csproj
+++ b/SimpleRabbit.NetCore/SimpleRabbit.NetCore.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="RabbitMq.Client" Version="5.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Added additional example project for multi-publisher configuration.

Service helper methods (still dependent on configuration) switched to taking in ConfigurationSection, so the naming of config is from application.

Removed Uri, in favor of username, password and hostnames.
Virtualhost added (still defaults to "/")
