### PR TITLE
Move watchdog timer

### DIFF
--- a/SimpleRabbit.NetCore.Publish/PublisherFactory.cs
+++ b/SimpleRabbit.NetCore.Publish/PublisherFactory.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Extensions.Options;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Concurrent;
 
@@ -13,11 +15,13 @@ namespace SimpleRabbit.NetCore.Publisher
     public class PublisherFactory : IDisposable
     {
         private readonly IOptionsMonitor<RabbitConfiguration> _optionsMonitor;
+        private readonly IServiceProvider _provider;
         public ConcurrentDictionary<string,IPublishService> _publishers;
-        public PublisherFactory(IOptionsMonitor<RabbitConfiguration> optionsMonitor)
+        public PublisherFactory(IOptionsMonitor<RabbitConfiguration> optionsMonitor, IServiceProvider provider)
         {
             _publishers = new ConcurrentDictionary<string, IPublishService>();
             _optionsMonitor = optionsMonitor;
+            _provider = provider;
             _optionsMonitor.OnChange((config,name) =>
             {
                 // a new one will be created when requested
@@ -43,7 +47,7 @@ namespace SimpleRabbit.NetCore.Publisher
         private IPublishService CreatePublisher(string name)
         {
             var options = _optionsMonitor.Get(name);
-            var publisher = new PublishService(options);
+            var publisher = new PublishService(_provider.GetService<ILogger<PublishService>>(),options);
 
             return publisher;
         }

--- a/SimpleRabbit.NetCore/Service/BasicRabbitService.cs
+++ b/SimpleRabbit.NetCore/Service/BasicRabbitService.cs
@@ -118,6 +118,12 @@ namespace SimpleRabbit.NetCore
             GC.SuppressFinalize(this);
         }
 
+
+        /// <summary>
+        /// Any additional things to clean up.
+        /// </summary>
+        protected virtual void Cleanup() { }
+
         protected virtual void Dispose(bool disposing)
         {
             if (!disposing || _disposed)
@@ -127,6 +133,7 @@ namespace SimpleRabbit.NetCore
 
             try
             {
+                Cleanup();
                 Close();
             }
             finally

--- a/SimpleRabbit.NetCore/Service/PublishService.cs
+++ b/SimpleRabbit.NetCore/Service/PublishService.cs
@@ -109,5 +109,11 @@ namespace SimpleRabbit.NetCore
             Close();
             _watchdogTimer.Stop();
         }
+
+        protected override void Cleanup()
+        {
+            base.Cleanup();
+            _watchdogTimer?.Dispose();
+        }
     }
 }

--- a/SimpleRabbit.NetCore/Service/PublishService.cs
+++ b/SimpleRabbit.NetCore/Service/PublishService.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Text;
+using System.Timers;
+using Microsoft.Extensions.Logging;
 using RabbitMQ.Client;
 
 namespace SimpleRabbit.NetCore
@@ -12,11 +14,35 @@ namespace SimpleRabbit.NetCore
 
     public class PublishService : BasicRabbitService, IPublishService
     {
+        /// <summary>
+        /// A Timer to check for an idle connection, to ensure a connection is not held open indefinitely.
+        /// </summary>
+        /// <remarks> 
+        /// Threading in the Connection prevent Console Applications from stopping if the connection
+        /// is not closed (i.e inside a using clause or not calling close).
+        /// </remarks>
+        private readonly Timer _watchdogTimer;
+        private readonly ILogger<PublishService> _logger;
+        protected long LastWatchDogTicks = DateTime.UtcNow.Ticks;
+
+
         public int InactivityPeriod { get; set; }
 
-        public PublishService(RabbitConfiguration options) : base(options)
+        public PublishService(ILogger<PublishService> logger, RabbitConfiguration options) : base(options)
         {
             InactivityPeriod = 30;
+
+            _watchdogTimer = new Timer
+            {
+                AutoReset = true,
+                Interval = InactivityPeriod * 1000, // in seconds
+                Enabled = false
+            };
+
+            _watchdogTimer.Elapsed += (sender, args) => { WatchdogExecution(); };
+
+            LastWatchDogTicks = DateTime.UtcNow.Ticks;
+            _logger = logger;
         }
 
         public void ToExchange(string exchange, string body, IBasicProperties properties = null, string route = "")
@@ -26,6 +52,11 @@ namespace SimpleRabbit.NetCore
 
         public void Publish(string exchange = "", string route = "", IBasicProperties properties = null, string body = null)
         {
+            if (!_watchdogTimer.Enabled)
+            {
+                _watchdogTimer.Start();
+            }
+
             if (string.IsNullOrWhiteSpace(exchange) && string.IsNullOrWhiteSpace(route))
             {
                 throw new Exception("Exchange (or route) must be provided.");
@@ -44,14 +75,39 @@ namespace SimpleRabbit.NetCore
             }
         }
 
-        protected override void OnWatchdogExecution()
+        private void WatchdogExecution()
+        {
+            var acquired = false;
+            try
+            {
+                _logger.LogTrace("Checking Watchdog timer");
+                System.Threading.Monitor.TryEnter(this, ref acquired);
+                if (!acquired)
+                {
+                    return;
+                }
+
+                OnWatchdogExecution();
+            }
+            finally
+            {
+                if (acquired)
+                {
+                    System.Threading.Monitor.Exit(this);
+                }
+            }
+        }
+
+        protected void OnWatchdogExecution()
         {
             if (LastWatchDogTicks >= DateTime.UtcNow.AddSeconds(-InactivityPeriod).Ticks)
             {
                 return;
             }
+            _logger.LogInformation($"Idle Rabbit Publishing Connection Detected, Clearing connection");
             LastWatchDogTicks = DateTime.UtcNow.Ticks;
             Close();
+            _watchdogTimer.Stop();
         }
     }
 }

--- a/SimpleRabbit.NetCore/Service/QueueService.cs
+++ b/SimpleRabbit.NetCore/Service/QueueService.cs
@@ -126,7 +126,6 @@ namespace SimpleRabbit.NetCore
 
         private void ReceiveEvent(object sender, BasicDeliverEventArgs args)
         {
-            LastWatchDogTicks = DateTime.UtcNow.Ticks;
             var channel = (sender as EventingBasicConsumer)?.Model;
             if (channel == null) throw new ArgumentNullException(nameof(sender), "Model null in received consumer event.");
 
@@ -147,17 +146,6 @@ namespace SimpleRabbit.NetCore
                 _logger.LogError(ex, $"{ex.Message} -> {args.DeliveryTag}: {args.BasicProperties.MessageId}");
                 RestartIn(TimeSpan.FromSeconds(_queueServiceParams.RetryInterval));
             }
-        }
-
-        protected override void OnWatchdogExecution()
-        {
-            if (LastWatchDogTicks >= DateTime.UtcNow.AddSeconds(-300).Ticks)
-            {
-                return;
-            }
-
-            LastWatchDogTicks = DateTime.UtcNow.AddMinutes(5).Ticks;
-            RestartIn(new TimeSpan(0, 0, 10));
         }
     }
 }


### PR DESCRIPTION
The watchdog timer as noted is a hack to stop indefinite wait time on publishing. As such this only applies to the publishing. This is also changed to Systems.Timer.Timer which has a stop ability, rather than relying on a -1 infinite period.

The timer is made to start only when the first publish is made (and closed when the connection is closed).

