### PR TITLE
Add Nack on Exception and messaging dropping error actions

### DIFF
--- a/SimpleRabbit.NetCore/Model/QueueConfiguration.cs
+++ b/SimpleRabbit.NetCore/Model/QueueConfiguration.cs
@@ -6,8 +6,36 @@
         public string ConsumerTag { get; set; }
         public string QueueName { get; set; }
         public ushort? PrefetchCount { get; set; }
-        public int RetryInterval { get; set; }
+        /// <summary>
+        /// On error, how long it waits until reattempting to restart consuming
+        /// </summary>
+        public int? RetryIntervalInSeconds { get; set; }
         public bool AutoBackOff { get; set; }
         public int HeartBeat { get; set; }
+        public ErrorAction OnErrorAction { get; set; }
+
+        public enum ErrorAction
+        {
+            /// <summary>
+            /// The connection will be completed cleared, and restarted in <see cref="RetryIntervalInSeconds"/>
+            /// </summary>
+            RestartConnection = 0,
+            /// <summary>
+            /// Messages will be requeued and consuming will start after the <see cref="RetryIntervalInSeconds"/>
+            /// </summary>
+            NackOnException = 1,
+            /// <summary>
+            /// Errorred messages will be Nacked and not requeued
+            /// </summary>
+            DropMessage = 2,
+            /// <summary>
+            /// Errored Messages will be Nacked and not requeued after the first time.
+            /// </summary>
+            /// <remarks>
+            /// There is a limit of one redelivery, as the internal flag is a boolean
+            /// https://github.com/rabbitmq/rabbitmq-server/issues/502
+            /// </remarks>
+            DropAfterOneRedelivery = 3
+        }
     }
 }

--- a/SimpleRabbit.NetCore/Service/QueueService.cs
+++ b/SimpleRabbit.NetCore/Service/QueueService.cs
@@ -3,6 +3,8 @@ using Timer = System.Timers.Timer;
 using Microsoft.Extensions.Logging;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
 
 namespace SimpleRabbit.NetCore
 {
@@ -16,14 +18,18 @@ namespace SimpleRabbit.NetCore
     public class QueueService : BasicRabbitService, IQueueService
     {
         private const int MaxRetryInterval = 120;
+        private const int DefaultRetryInterval = 15;
 
         private readonly ILogger<QueueService> _logger;
 
         private readonly Timer _timer;
         private QueueConfiguration _queueServiceParams;
-
         private IMessageHandler _handler;
+        private TimeSpan RetryInterval => TimeSpan.FromSeconds(_queueServiceParams?.RetryIntervalInSeconds ?? DefaultRetryInterval);
+        
         private int _retryCount;
+
+        private ConcurrentBag<ulong> _toBeNackedMessages = new ConcurrentBag<ulong>();
 
         public QueueService(RabbitConfiguration options, ILogger<QueueService> logger) : base(options)
         {
@@ -37,37 +43,8 @@ namespace SimpleRabbit.NetCore
             _timer.Elapsed += (sender, args) =>
             {
                 _timer.Stop();
-                Start();
+                TimerActivation();
             };
-        }
-
-        private void RestartIn(TimeSpan waitInterval)
-        {
-            try
-            {
-                // attempt to stop the event consumption.
-                Channel?.BasicCancel(_queueServiceParams.ConsumerTag);
-            }
-            catch
-            {
-                // ignored
-            }
-
-            try
-            {
-                Close();
-            }
-            catch
-            {
-                // Ignored
-            }
-
-            _retryCount++;
-            var interval = waitInterval.TotalSeconds * (_queueServiceParams.AutoBackOff ? _retryCount : 1) % MaxRetryInterval;
-
-            _timer.Interval = interval * 1000;
-            _logger.LogInformation($" -> restarting connection in {interval} seconds ({_retryCount}).");
-            _timer.Start();
         }
 
         public void Start(string queue, string tag, IMessageHandler handler, ushort prefetch = 1)
@@ -77,7 +54,6 @@ namespace SimpleRabbit.NetCore
                 PrefetchCount = prefetch,
                 QueueName = queue,
                 ConsumerTag = tag,
-                RetryInterval = 30
             };
             _handler = handler;
 
@@ -87,10 +63,6 @@ namespace SimpleRabbit.NetCore
         public void Start(QueueConfiguration subscriberConfiguration, IMessageHandler handler)
         {
             _queueServiceParams = subscriberConfiguration;
-            if (_queueServiceParams.RetryInterval == 0)
-            {
-                _queueServiceParams.RetryInterval = 30;
-            }
             _handler = handler;
 
             Start();
@@ -115,14 +87,10 @@ namespace SimpleRabbit.NetCore
             catch (Exception e)
             {
                 _logger.LogError(e, $"{_queueServiceParams.QueueName} -> {e.Message}");
-                RestartIn(TimeSpan.FromSeconds(_queueServiceParams.RetryInterval));
+                RestartIn(RetryInterval);
             }
         }
 
-        public void Stop()
-        {
-            Close();
-        }
 
         private void ReceiveEvent(object sender, BasicDeliverEventArgs args)
         {
@@ -133,7 +101,7 @@ namespace SimpleRabbit.NetCore
             try
             {
                 var message = new BasicMessage(args, channel, _queueServiceParams.QueueName,
-                    () => RestartIn(TimeSpan.FromSeconds(_queueServiceParams.RetryInterval)));
+                    () => OnError(sender,args));
 
                 if (_handler.Process(message))
                 {
@@ -145,9 +113,125 @@ namespace SimpleRabbit.NetCore
             {
                 // error processing message
                 _logger.LogError(ex, $"{ex.Message} -> {args.DeliveryTag}: {args.BasicProperties.MessageId}");
-                RestartIn(TimeSpan.FromSeconds(_queueServiceParams.RetryInterval));
+                RestartIn(RetryInterval);
             }
         }
+
+        private void OnError(object sender, BasicDeliverEventArgs message)
+        {
+            try
+            {
+                var channel = (sender as IBasicConsumer)?.Model;
+
+                switch (_queueServiceParams.OnErrorAction)
+                {
+                    case QueueConfiguration.ErrorAction.DropAfterOneRedelivery:
+                    {
+                        if (message.Redelivered)
+                        {
+                            goto case QueueConfiguration.ErrorAction.DropMessage;
+                        }
+                        channel.BasicNack(message.DeliveryTag, false, true);
+                        _logger.LogInformation($" -> nacked message on queue {_queueServiceParams.QueueName}");
+                        return;
+                    }
+                    case QueueConfiguration.ErrorAction.DropMessage:
+                    {
+                        channel.BasicNack(message.DeliveryTag, false, false);
+                        _logger.LogInformation($" -> dropped message on queue {_queueServiceParams.QueueName}");
+                        return;
+                    }
+                    case QueueConfiguration.ErrorAction.NackOnException:
+                    {
+                        if (channel == null || channel.IsClosed)
+                        {
+                            RestartIn(RetryInterval);
+                        }
+                        else
+                        {
+                            //queue up message to be nacked on restart.
+                            _toBeNackedMessages.Add(message.DeliveryTag);
+                            RestartIn(RetryInterval);
+                        }
+                        return;
+                    }
+                    case QueueConfiguration.ErrorAction.RestartConnection:
+                    default:
+                    {
+                       
+                        RestartIn(RetryInterval);
+                        return;
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, $"An error occured while trying to handle another error, restarting connection");
+                RestartIn(RetryInterval);
+                return;
+            }
+        }
+
+        private void RestartIn(TimeSpan waitInterval)
+        {
+            if (_timer.Enabled)
+            {
+                // another message has already triggered an error.
+                return;
+                
+            }
+
+            if (_queueServiceParams.OnErrorAction == QueueConfiguration.ErrorAction.RestartConnection)
+            {
+                try
+                {
+                    //take note of blocking if clearing connection here
+                    //https://github.com/rabbitmq/rabbitmq-dotnet-client/issues/341
+                    // attempt to stop the event consumption.
+                    Channel?.BasicCancel(_queueServiceParams.ConsumerTag);
+                }
+                catch
+                {
+                    // ignored
+                }
+            }
+
+            _retryCount++;
+            var interval = waitInterval.TotalSeconds * (_queueServiceParams.AutoBackOff ? _retryCount : 1) % MaxRetryInterval;
+
+            _timer.Interval = interval * 1000; // seconds
+            _logger.LogInformation($" -> restarting in {interval} seconds ({_retryCount}).");
+            _timer.Start();
+        }
+
+        private void TimerActivation()
+        {
+            switch (_queueServiceParams.OnErrorAction)
+            {
+                case QueueConfiguration.ErrorAction.NackOnException:
+                {
+                    foreach (var message in _toBeNackedMessages)
+                    {
+                        Channel.BasicNack(message, false, false);
+                    }
+                    _toBeNackedMessages.Clear();
+                    return;
+                }
+                case QueueConfiguration.ErrorAction.RestartConnection:
+                default:
+                {
+                    Start();
+                    return;
+                }
+            }
+        }
+
+        public void Stop()
+        {
+            Close();
+        }
+
+        
 
         protected override void OnWatchdogExecution()
         {


### PR DESCRIPTION
Adding in check so timer isn't constantly restarted for all errored messages.

New behaviours
Nack - The connection and channel are left opened, however the bad messages are not Nacked until the reset period

Drop Messages - The messages are Nacked but not registered to be Requeued. This can be used in conjuction with dead letter queues https://www.rabbitmq.com/dlx.html

