### PR TITLE
Release message

### DIFF
--- a/SimpleRabbit.NetCore/Service/QueueService.cs
+++ b/SimpleRabbit.NetCore/Service/QueueService.cs
@@ -157,8 +157,8 @@ namespace SimpleRabbit.NetCore
                     case QueueConfiguration.ErrorAction.RestartConnection:
                     default:
                     {
-                       
                         RestartIn(RetryInterval);
+                        channel.BasicNack(message.DeliveryTag, false, true);
                         return;
                     }
                 }


### PR DESCRIPTION
Nack the message on restarting connection to release the message 
There is a basic consume cancel, so it should not receive the message again