### PR TITLE
Add tests, small fixes

### DIFF
--- a/SimpleRabbit.NetCore.Tests/BasicRabbitServiceTests.cs
+++ b/SimpleRabbit.NetCore.Tests/BasicRabbitServiceTests.cs
@@ -1,0 +1,193 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using RabbitMQ.Client;
+using SimpleRabbit.NetCore.Tests.implementations;
+using System;
+using System.Collections.Generic;
+using System.Security.Authentication;
+
+namespace SimpleRabbit.NetCore.Tests
+{
+    [TestFixture]
+    public class BasicRabbitServiceTests
+    {
+
+        [Test]
+        public void SingletonAttributes()
+        {
+            var service = new ExposedRabbitService(ExposedRabbitService.validConfig);
+
+            var factory1 = service.ExposedFactory;
+            var connection1 = service.ExposedConnection;
+            var channel1 = service.ExposedChannel;
+
+
+            var factory2 = service.ExposedFactory;
+            var connection2 = service.ExposedConnection;
+            var channel2 = service.ExposedChannel;
+
+            service.Dispose();
+
+            factory1.Should().BeSameAs(factory2);
+            connection1.Should().BeSameAs(connection2);
+            channel1.Should().BeSameAs(channel2);
+
+        }
+
+        [Test]
+        public void ClearConnection()
+        {
+            var service = new ExposedRabbitService(ExposedRabbitService.validConfig);
+            var factory1 = service.ExposedFactory;
+            var connection1 = service.ExposedConnection;
+            var channel1 = service.ExposedChannel;
+
+            service.ClearConnection();
+            var factory2 = service.ExposedFactory;
+            var connection2 = service.ExposedConnection;
+            var channel2 = service.ExposedChannel;
+
+            connection1.IsOpen.Should().BeFalse();
+            channel1.IsClosed.Should().BeTrue();
+
+            factory1.Should().BeSameAs(factory2);
+            connection1.Should().NotBeSameAs(connection2);
+            channel1.Should().NotBeSameAs(channel2);
+
+            service.Dispose();
+        }
+
+        [Test]
+        public void CloseConnection()
+        {
+            var service = new ExposedRabbitService(ExposedRabbitService.validConfig);
+            var factory1 = service.ExposedFactory;
+            var connection1 = service.ExposedConnection;
+            var channel1 = service.ExposedChannel;
+
+            service.Close();
+            var factory2 = service.ExposedFactory;
+            var connection2 = service.ExposedConnection;
+            var channel2 = service.ExposedChannel;
+
+            connection1.IsOpen.Should().BeFalse();
+            channel1.IsClosed.Should().BeTrue();
+
+            factory1.Should().NotBeSameAs(factory2);
+            connection1.Should().NotBeSameAs(connection2);
+            channel1.Should().NotBeSameAs(channel2);
+
+            service.Dispose();
+        }
+
+        [Test]
+        public void DefaultFactoryValues()
+        {
+            var service = new ExposedRabbitService(ExposedRabbitService.validConfig);
+            var factory1 = service.ExposedFactory;
+
+            factory1.UserName.Should().Be(ExposedRabbitService.validConfig.Username);
+            factory1.Password.Should().Be(ExposedRabbitService.validConfig.Password);
+
+            factory1.VirtualHost.Should().Be(ConnectionFactory.DefaultVHost);
+            factory1.AutomaticRecoveryEnabled.Should().BeTrue();
+            factory1.NetworkRecoveryInterval.Should().Be(TimeSpan.FromSeconds(10));
+            factory1.TopologyRecoveryEnabled.Should().BeTrue();
+            factory1.RequestedHeartbeat.Should().Be(5);
+
+            service.Dispose();
+        }
+
+        [Test]
+        public void OverrideFactoryValues()
+        {
+            var config = new RabbitConfiguration
+            {
+                Username = "guest",
+                Password = "guest",
+                Hostnames = new List<string> { "localhost" },
+                VirtualHost = "/ex",
+                AutomaticRecoveryEnabled = false,
+                NetworkRecoveryIntervalInSeconds = 5,
+                TopologyRecoveryEnabled = false,
+                RequestedHeartBeat = 20
+            };
+            var service = new ExposedRabbitService(config);
+            var factory1 = service.ExposedFactory;
+
+            factory1.UserName.Should().Be(config.Username);
+            factory1.Password.Should().Be(config.Password);
+
+            factory1.VirtualHost.Should().Be("/ex");
+            factory1.AutomaticRecoveryEnabled.Should().BeFalse();
+            factory1.NetworkRecoveryInterval.Should().Be(TimeSpan.FromSeconds(5));
+            factory1.TopologyRecoveryEnabled.Should().BeFalse();
+            factory1.RequestedHeartbeat.Should().Be(20);
+
+            service.Dispose();
+        }
+
+        [Test]
+        public void NoUsernameProvided()
+        {
+            var config = new RabbitConfiguration
+            {
+                Password = "guest",
+                Hostnames = new List<string> { "localhost" }
+            };
+            var service = new ExposedRabbitService(config);
+            service.Invoking(y => y.ExposedFactory).Should().Throw<InvalidCredentialException>();
+
+            service.Dispose();
+        }
+
+        [Test]
+        public void NoPasswordProvided()
+        {
+            var config = new RabbitConfiguration
+            {
+                Username = "guest",
+                Hostnames = new List<string> { "localhost" }
+            };
+            var service = new ExposedRabbitService(config);
+            service.Invoking(y => y.ExposedFactory).Should().Throw<InvalidCredentialException>();
+
+            service.Dispose();
+        }
+
+        [Test]
+        public void NoHostnamesProvided()
+        {
+            var config = new RabbitConfiguration
+            {
+                Password = "guest",
+                Username = "guest",
+            };
+            var service = new ExposedRabbitService(config);
+            service.Invoking(y => y.ExposedFactory).Should().Throw<ArgumentNullException>();
+
+            service.Dispose();
+        }
+
+        [Test]
+        public void EmptyHostnamesProvided()
+        {
+            var config = new RabbitConfiguration
+            {
+                Password = "guest",
+                Username = "guest",
+                Hostnames = new List<string>()
+            };
+            var service = new ExposedRabbitService(config);
+            service.Invoking(y => y.ExposedFactory).Should().Throw<ArgumentNullException>();
+
+            service.Dispose();
+        }
+    }
+
+
+
+
+
+
+}

--- a/SimpleRabbit.NetCore.Tests/IntegrationFixture.cs
+++ b/SimpleRabbit.NetCore.Tests/IntegrationFixture.cs
@@ -1,0 +1,65 @@
+﻿using NUnit.Framework;
+using SimpleRabbit.NetCore.Tests.implementations;
+using Subscriber.Service.Service;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SimpleRabbit.NetCore.Tests
+{
+    /// <summary>
+    /// Provide a basic fixture for testing with a local rabbit mq server.
+    /// </summary>
+    [Category("Require RabbitMQ")]
+    public class IntegrationFixture
+    {
+        protected const int TimeoutPeriod = 4;
+        protected const int RoundTripWaitTime = 500;
+        protected static readonly string QueueName = "MyQueue";
+        protected static readonly string ExchangeName = "MyExchange";
+        
+        protected MessageProcessor handler;
+
+        /// <summary>
+        /// A service linked up to the queue so that it can be managed before each test execution.
+        /// </summary>
+        protected ExposedRabbitService basicService;
+
+        [OneTimeSetUp]
+        public void CreateBasicService()
+        {
+
+            handler = new MessageProcessor();
+            // Get the channel so it can be purged before each test
+            basicService = new ExposedRabbitService(ExposedRabbitService.validConfig);
+        }
+
+        [OneTimeTearDown]
+        public void DisposeBasicServices()
+        {
+            basicService.Dispose();
+        }
+
+        [SetUp]
+        public void EmptyQueue()
+        {
+            basicService.ExposedChannel.QueuePurge(QueueName);
+        }
+
+        protected Task WaitorEndEarly(CancellationToken token)
+        {
+            return WaitorEndEarly(TimeSpan.FromSeconds(TimeoutPeriod), token);
+
+        }
+
+        protected async Task WaitorEndEarly(TimeSpan timeout, CancellationToken token)
+        {
+            try
+            {
+                await Task.Delay(timeout, token);
+            }
+            catch (TaskCanceledException) { }
+
+        }
+    }
+}

--- a/SimpleRabbit.NetCore.Tests/SimpleRabbit.NetCore.Tests.csproj
+++ b/SimpleRabbit.NetCore.Tests/SimpleRabbit.NetCore.Tests.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SimpleRabbit.NetCore\SimpleRabbit.NetCore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/SimpleRabbit.NetCore.Tests/SingleMessageTest.cs
+++ b/SimpleRabbit.NetCore.Tests/SingleMessageTest.cs
@@ -1,0 +1,162 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using SimpleRabbit.NetCore.Tests.implementations;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SimpleRabbit.NetCore.Tests
+{
+    /// <summary>
+    /// Full integration (publsiher + subscriber) with rabbitMQ server.
+    /// </summary>
+    [TestFixture]
+    [NonParallelizable]
+    public class SingleMessageTest : IntegrationFixture
+    {
+        protected PublishService publisher;
+        protected QueueService queue;
+        private BasicMessage recieved;
+        protected CancellationTokenSource tokenSource;
+        protected Mock<ILogger<PublishService>> publisherlogger;
+        protected Mock<ILogger<QueueService>> subscriberlogger;
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            publisherlogger = new Mock<ILogger<PublishService>>();
+            subscriberlogger = new Mock<ILogger<QueueService>>();
+            publisher = new PublishService(publisherlogger.Object, ExposedRabbitService.validConfig);
+           
+            queue = new QueueService(ExposedRabbitService.validConfig, subscriberlogger.Object);
+            handler.Handler = Process;
+        }
+
+        private bool Process(BasicMessage args)
+        {
+            recieved = args;
+            tokenSource.Cancel();
+            return true;
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            publisher.Dispose();
+            queue.Dispose();
+            handler.Handler = null;
+        }
+
+        [SetUp]
+        public void StartQueue()
+        {
+            var queueConfig = new QueueConfiguration
+            {
+                QueueName = QueueName,
+                PrefetchCount = 1,
+                OnErrorAction = QueueConfiguration.ErrorAction.RestartConnection,
+                ConsumerTag = "consumer"
+            };
+            tokenSource = new CancellationTokenSource();
+            queue.Start(queueConfig, handler);
+
+        }
+
+        [TearDown]
+        public void StopQueue()
+        {
+            
+            queue.Stop();
+            tokenSource.Dispose();
+        }
+
+
+        [Test]
+        public async Task PublishEmptyMessage()
+        {
+
+            publisher.Publish(ExchangeName, null);
+
+            await WaitorEndEarly(tokenSource.Token);
+
+            recieved.Body.Should().BeEmpty();
+        }
+
+        [Test]
+        public async Task PublishDirect()
+        {
+            var message = "hey";
+
+            publisher.Publish("", QueueName, body: message);
+
+            await WaitorEndEarly(tokenSource.Token);
+
+            recieved.Body.Should().Be(message);
+        }
+
+        [Test]
+        public async Task PublishWithExchange()
+        {
+            var message = "hey";
+
+            publisher.Publish(ExchangeName, null, body: message);
+
+            await WaitorEndEarly(tokenSource.Token);
+
+            recieved.Body.Should().Be(message);
+        }
+
+        [Test]
+        public async Task ToExchange()
+        {
+            var message = "hey";
+
+            publisher.ToExchange(ExchangeName, body: message);
+
+            await WaitorEndEarly(tokenSource.Token);
+
+            recieved.Body.Should().Be(message);
+        }
+
+        [Test]
+        public async Task PublishWithProperties()
+        {
+            var message = "hey";
+            var list = new List<string> { "bob", "alice", "charles" };
+            var properties = publisher.GetBasicProperties();
+            properties.AppId = "App";
+            properties.Headers = new Dictionary<string, object>
+            {
+                { "hi", list }
+            };
+
+
+            publisher.Publish(ExchangeName, null, properties, message);
+
+            await WaitorEndEarly(tokenSource.Token);
+
+            recieved.Body.Should().Be(message);
+            recieved.Properties.AppId.Should().Be(properties.AppId);
+            recieved.Headers.Should().ContainKey("hi")
+                .WhichValue.Should().BeEquivalentTo(list.Select(s => Encoding.UTF8.GetBytes(s)));
+
+        }
+
+
+        [Test]
+        public async Task PublishWithException()
+        {
+            var message = "exception";
+            publisher.Publish(ExchangeName, null, body: message);
+
+            await WaitorEndEarly(tokenSource.Token);
+
+            recieved.Body.Should().Be(message);
+        }
+
+
+    }
+}

--- a/SimpleRabbit.NetCore.Tests/Subcriber/QueueExceptionTests.cs
+++ b/SimpleRabbit.NetCore.Tests/Subcriber/QueueExceptionTests.cs
@@ -1,0 +1,216 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using SimpleRabbit.NetCore.Tests.implementations;
+using System;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SimpleRabbit.NetCore.Tests
+{
+    public class TestMessages
+    {
+        public const string Exception = "Exception";
+        public const string Redeliver = "Redeliver";
+        public const string Pass = "Pass";
+    }
+    /// <summary>
+    /// Testing <see cref="BaseQueueService"/> error behaviour
+    /// </summary>
+    [TestFixture]
+    [NonParallelizable]
+    public class QueueExceptionTests : IntegrationFixture
+    {
+        private int successCount;
+        private int errorCount;
+        private int processCount;
+        protected Mock<ILogger<QueueService>> subscriberlogger;
+        [OneTimeSetUp]
+        public void AddHandlerEvent()
+        {
+            subscriberlogger = new Mock<ILogger<QueueService>>();
+            handler.Handler = Process;
+        }
+
+        private bool Process(BasicMessage args)
+        {
+            processCount++;
+            if (args.Body.Equals(TestMessages.Exception) || // always throw exception
+                (args.Body.Equals(TestMessages.Redeliver) && !args.DeliveryArgs.Redelivered)) //first time fail, second pass
+            {
+                errorCount++;
+                throw new Exception("error");
+            }
+            successCount++;
+            return true;
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            handler.Handler -= Process;
+        }
+
+        [SetUp]
+        public void ResetFlag()
+        {
+            processCount = 0;
+            errorCount = 0;
+            successCount = 0;
+        }
+
+        [Test]
+        public async Task RestartOnConnection()
+        {
+            var queueConfig = new QueueConfiguration
+            {
+                QueueName = QueueName,
+                PrefetchCount = 1,
+                OnErrorAction = QueueConfiguration.ErrorAction.RestartConnection,
+                ConsumerTag = "consumer",
+                RetryIntervalInSeconds = 2
+            };
+            var queue = new QueueService(ExposedRabbitService.validConfig, subscriberlogger.Object);
+            queue.Start(queueConfig, handler);
+
+            var initialConsumerCount = basicService.ExposedChannel.ConsumerCount(QueueName);
+
+            basicService.ExposedChannel.BasicPublish(ExchangeName, "", true, null, Encoding.UTF8.GetBytes(TestMessages.Redeliver));
+            await Task.Delay(RoundTripWaitTime);
+
+            var inbetweenConsumerCount = basicService.ExposedChannel.ConsumerCount(QueueName);
+
+            await Task.Delay(2000 + RoundTripWaitTime); // wait retry interval + RoundTrip
+
+            var finalConsumerCount = basicService.ExposedChannel.ConsumerCount(QueueName);
+
+            queue.Dispose();
+
+            successCount.Should().Be(1, "because item is not excepted twice");
+            processCount.Should().Be(2, "because first time exception, second time succesful process");
+            initialConsumerCount.Should().Be(1);
+            inbetweenConsumerCount.Should().Be(0, "because the channel restarts");
+            errorCount.Should().Be(1, "because error should be thrown first time");
+            finalConsumerCount.Should().Be(1);
+        }
+
+        [Test]
+        public async Task NackOnException()
+        {
+            var queueConfig = new QueueConfiguration
+            {
+                QueueName = QueueName,
+                PrefetchCount = 1,
+                OnErrorAction = QueueConfiguration.ErrorAction.NackOnException,
+                ConsumerTag = "consumer",
+                RetryIntervalInSeconds = 1
+            };
+            var queue = new QueueService(ExposedRabbitService.validConfig, subscriberlogger.Object);
+            queue.Start(queueConfig, handler);
+
+            var initialConsumerCount = basicService.ExposedChannel.ConsumerCount(QueueName);
+            basicService.ExposedChannel.BasicPublish(ExchangeName, "", true, null, Encoding.UTF8.GetBytes(TestMessages.Redeliver));
+            await Task.Delay(RoundTripWaitTime);
+
+            var inbetweenConsumerCount = basicService.ExposedChannel.ConsumerCount(QueueName);
+
+            await Task.Delay(1000+RoundTripWaitTime);
+
+            var finalConsumerCount = basicService.ExposedChannel.ConsumerCount(QueueName);
+
+            queue.Dispose();
+
+            successCount.Should().Be(1, "because item is not excepted twice");
+            processCount.Should().Be(2, "because first time exception, second time succesful process");
+            initialConsumerCount.Should().Be(1);
+            inbetweenConsumerCount.Should().Be(1, "because only the message is nacked");
+            errorCount.Should().Be(1, "because error should be thrown first time");
+            finalConsumerCount.Should().Be(1);
+        }
+
+        [Test]
+        public async Task DropMessage()
+        {
+            var queueConfig = new QueueConfiguration
+            {
+                QueueName = QueueName,
+                PrefetchCount = 1,
+                OnErrorAction = QueueConfiguration.ErrorAction.DropMessage,
+                ConsumerTag = "consumer",
+                RetryIntervalInSeconds = 1
+            };
+            var queue = new QueueService(ExposedRabbitService.validConfig, subscriberlogger.Object);
+            queue.Start(queueConfig, handler);
+
+            var initialConsumerCount = basicService.ExposedChannel.ConsumerCount(QueueName);
+            basicService.ExposedChannel.BasicPublish(ExchangeName, "", true, null, Encoding.UTF8.GetBytes(TestMessages.Redeliver));
+            await Task.Delay(RoundTripWaitTime);
+
+            var finalConsumerCount = basicService.ExposedChannel.ConsumerCount(QueueName);
+            queue.Dispose();
+
+            processCount.Should().Be(1, "because the message is dropped");
+            initialConsumerCount.Should().Be(1);
+            errorCount.Should().Be(1);
+            finalConsumerCount.Should().Be(1, "because consumer shouldn't have stopped");
+        }
+
+
+        [Test]
+        public async Task LetInFlightMessagesContinue()
+        {
+            var queueConfig = new QueueConfiguration
+            {
+                QueueName = QueueName,
+                PrefetchCount = 3,
+                OnErrorAction = QueueConfiguration.ErrorAction.RestartConnection,
+                ConsumerTag = "consumer",
+                RetryIntervalInSeconds = 10
+            };
+            var queue = new QueueService(ExposedRabbitService.validConfig, subscriberlogger.Object);
+            queue.Start(queueConfig, handler);
+            basicService.ExposedChannel.BasicPublish(ExchangeName, "", true, null, Encoding.UTF8.GetBytes(TestMessages.Pass));
+            basicService.ExposedChannel.BasicPublish(ExchangeName, "", true, null, Encoding.UTF8.GetBytes(TestMessages.Exception));
+            basicService.ExposedChannel.BasicPublish(ExchangeName, "", true, null, Encoding.UTF8.GetBytes(TestMessages.Pass));
+            await Task.Delay(RoundTripWaitTime);
+
+            queue.Dispose();
+            var finalMessageCount = basicService.ExposedChannel.MessageCount(QueueName);
+
+            processCount.Should().Be(3, "because 3 messages were sent");
+            successCount.Should().Be(2, "because 2 successful messages were sent");
+            errorCount.Should().Be(1);
+            finalMessageCount.Should().Be(1, "because only one message caused exception");
+        }
+
+
+        [Test]
+        public async Task ReleaseHeldMessages()
+        {
+            var queueConfig = new QueueConfiguration
+            {
+                QueueName = QueueName,
+                PrefetchCount = 1,
+                OnErrorAction = QueueConfiguration.ErrorAction.RestartConnection,
+                ConsumerTag = "consumer",
+                RetryIntervalInSeconds = 10
+            };
+            var queue = new QueueService(ExposedRabbitService.validConfig, subscriberlogger.Object);
+            queue.Start(queueConfig, handler);
+            basicService.ExposedChannel.BasicPublish(ExchangeName, "", true, null, Encoding.UTF8.GetBytes(TestMessages.Exception));
+            await Task.Delay(RoundTripWaitTime);
+
+            var freeMessages = basicService.ExposedChannel.MessageCount(QueueName);
+
+            queue.Dispose();
+            var finalMessageCount = basicService.ExposedChannel.MessageCount(QueueName);
+
+            processCount.Should().Be(1, "because 1 messages were sent");
+            successCount.Should().Be(0, "because 0 successful messages were sent");
+            errorCount.Should().Be(1);
+            freeMessages.Should().Be(1, "because excepted messages should be released");
+            finalMessageCount.Should().Be(1, "because only one message caused exception");
+        }
+    }
+}

--- a/SimpleRabbit.NetCore.Tests/Subcriber/QueuePrefetchTests.cs
+++ b/SimpleRabbit.NetCore.Tests/Subcriber/QueuePrefetchTests.cs
@@ -1,0 +1,139 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using SimpleRabbit.NetCore.Tests.implementations;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SimpleRabbit.NetCore.Tests
+{
+    /// <summary>
+    /// Testing prefetch of a basic service.
+    /// </summary>
+    [TestFixture]
+    [NonParallelizable]
+    public class QueuePrefetchTests : IntegrationFixture
+    {
+        private uint processCount;
+        protected Mock<ILogger<QueueService>> subscriberlogger;
+        [OneTimeSetUp]
+        public void AddHandlerEvent()
+        {
+            subscriberlogger = new Mock<ILogger<QueueService>>();
+            handler.Handler = Process;
+        }
+
+        private bool Process(BasicMessage args)
+        {
+            processCount++;
+            // don't pick up the messages, so no more events come after the prefetch limit is reached
+            return false;
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            handler.Handler -= Process;
+        }
+
+        [SetUp]
+        public void ResetFlag()
+        {
+            processCount = 0;
+        }
+
+        [TestCase(1u, 0)]
+        [TestCase(1u, 1)]
+        [TestCase(1u, 2)]
+        [TestCase(3u, 1)]
+        [TestCase(3u, 3)]
+        [TestCase(3u, 5)]
+        [TestCase(5u, 2)]
+        [TestCase(5u, 4)]
+        [TestCase(5u, 5)]
+        [TestCase(5u, 10)]
+        public async Task ProcessAllPrefetch(uint prefetch, int numberofMessages)
+        {
+            var queueConfig = new QueueConfiguration
+            {
+                QueueName = QueueName,
+                PrefetchCount = (ushort)prefetch,
+                OnErrorAction = QueueConfiguration.ErrorAction.RestartConnection,
+                ConsumerTag = "consumer",
+                RetryIntervalInSeconds = 10
+            };
+            var queue = new QueueService(ExposedRabbitService.validConfig, subscriberlogger.Object);
+
+            for (int _ = 0; _ < numberofMessages; _++)
+            {
+                basicService.ExposedChannel.BasicPublish(ExchangeName, "", true, null, Encoding.UTF8.GetBytes("message"));
+            }
+            queue.Start(queueConfig, handler);
+
+            await Task.Delay(RoundTripWaitTime);// let queue pick up messages
+            var finalMessageCount = basicService.ExposedChannel.MessageCount(QueueName);
+            queue.Dispose();
+
+
+            if (numberofMessages > prefetch)
+            {
+                finalMessageCount.Should().Be((uint)numberofMessages - prefetch, "because there are {0} messages with {1} prefetch", numberofMessages, prefetch);
+                processCount.Should().Be(prefetch, "because the prefetch is {0}", prefetch);
+            }
+            // if prefetch is greater than message number, then the final count should be 0.
+            else
+            {
+                finalMessageCount.Should().Be(0, "because the are messages in queue exceeds prefetch");
+                processCount.Should().Be((uint)numberofMessages, "because the prefetch exceeds number of messages");
+            }
+
+        }
+
+        [TestCase(1u, 0)]
+        [TestCase(1u, 1)]
+        [TestCase(1u, 2)]
+        [TestCase(3u, 1)]
+        [TestCase(3u, 3)]
+        [TestCase(3u, 5)]
+        [TestCase(5u, 2)]
+        [TestCase(5u, 4)]
+        [TestCase(5u, 5)]
+        [TestCase(5u, 6)]
+        public async Task DripFeedMessages(uint prefetch, int numberofMessages)
+        {
+            var queueConfig = new QueueConfiguration
+            {
+                QueueName = QueueName,
+                PrefetchCount = (ushort)prefetch,
+                OnErrorAction = QueueConfiguration.ErrorAction.RestartConnection,
+                ConsumerTag = "consumer",
+                RetryIntervalInSeconds = 10
+            };
+            var queue = new QueueService(ExposedRabbitService.validConfig, subscriberlogger.Object);
+            queue.Start(queueConfig, handler);
+
+            for (uint messagecount = 1; messagecount < numberofMessages+1; messagecount++)
+            {
+                basicService.ExposedChannel.BasicPublish(ExchangeName, "", true, null, Encoding.UTF8.GetBytes("message"));
+                await Task.Delay(RoundTripWaitTime);
+                var queueMessageCount = basicService.ExposedChannel.MessageCount(QueueName);
+
+                if (prefetch > messagecount)
+                {
+                    queueMessageCount.Should().Be(0, "because there are {0} messages with {1} prefetch", messagecount, prefetch);
+                    processCount.Should().Be(messagecount, "because the prefetch is {0}", prefetch);
+                }
+                // if prefetch is greater than message number, then the final count should be 0.
+                else
+                {
+                    queueMessageCount.Should().Be(messagecount - prefetch, "because there are messages in queue exceeds prefetch");
+                    processCount.Should().Be(prefetch, "because the prefetch exceeds number of messages");
+                }
+
+            }
+            queue.Dispose();
+
+        }
+    }
+}

--- a/SimpleRabbit.NetCore.Tests/implementations/ExposedConsumer.cs
+++ b/SimpleRabbit.NetCore.Tests/implementations/ExposedConsumer.cs
@@ -1,0 +1,38 @@
+﻿using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+using System;
+
+namespace SimpleRabbit.NetCore.Tests.implementations
+{
+    public class ExposedConsumer : IBasicConsumer
+    {
+        public IModel Model { get; set; }
+
+        public event EventHandler<ConsumerEventArgs> ConsumerCancelled;
+
+        public void HandleBasicCancel(string consumerTag)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void HandleBasicCancelOk(string consumerTag)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void HandleBasicConsumeOk(string consumerTag)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, IBasicProperties properties, byte[] body)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void HandleModelShutdown(object model, ShutdownEventArgs reason)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/SimpleRabbit.NetCore.Tests/implementations/ExposedQueueService.cs
+++ b/SimpleRabbit.NetCore.Tests/implementations/ExposedQueueService.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.Extensions.Logging;
+using RabbitMQ.Client;
+
+namespace SimpleRabbit.NetCore.Tests.implementations
+{
+
+    public class ExposedQueueService : QueueService
+    {
+
+        public ExposedQueueService(ILogger<QueueService> logger, RabbitConfiguration rabbitConfig) : base(rabbitConfig, logger)
+        {
+            Consumer = new ExposedConsumer { Model = ExposedChannel };
+        }
+
+        public ConnectionFactory ExposedFactory { get => Factory; }
+        public IConnection ExposedConnection { get => Connection; }
+        public IModel ExposedChannel { get => Channel; }
+        public ExposedConsumer Consumer { get; }
+    }
+}

--- a/SimpleRabbit.NetCore.Tests/implementations/ExposedRabbitService.cs
+++ b/SimpleRabbit.NetCore.Tests/implementations/ExposedRabbitService.cs
@@ -1,0 +1,25 @@
+﻿using RabbitMQ.Client;
+using System.Collections.Generic;
+
+namespace SimpleRabbit.NetCore.Tests.implementations
+{
+
+    public class ExposedRabbitService : BasicRabbitService
+    {
+        public static RabbitConfiguration validConfig = new RabbitConfiguration
+        {
+            Username = "guest",
+            Password = "guest",
+            Hostnames = new List<string> { "localhost" },
+        };
+
+        public ExposedRabbitService(RabbitConfiguration config) : base(config)
+        {
+
+        }
+
+        public ConnectionFactory ExposedFactory { get => Factory; }
+        public IConnection ExposedConnection { get => Connection; }
+        public IModel ExposedChannel { get => Channel; }
+    }
+}

--- a/SimpleRabbit.NetCore.Tests/implementations/MessageProcessor.cs
+++ b/SimpleRabbit.NetCore.Tests/implementations/MessageProcessor.cs
@@ -1,0 +1,19 @@
+﻿using SimpleRabbit.NetCore;
+using System;
+
+namespace Subscriber.Service.Service
+{
+    public class MessageProcessor : IMessageHandler
+    {
+        public Func<BasicMessage, bool> Handler;
+        public bool CanProcess(string tag)
+        {
+            return true;
+        }
+
+        public bool Process(BasicMessage message)
+        {
+            return Handler.Invoke(message);
+        }
+    }
+}

--- a/SimpleRabbit.NetCore.sln
+++ b/SimpleRabbit.NetCore.sln
@@ -19,6 +19,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Multi-Subscriber.Service", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SimpleRabbit.NetCore.Publish", "SimpleRabbit.NetCore.Publish\SimpleRabbit.NetCore.Publish.csproj", "{FB1DF967-5993-4E06-8A2C-58815F460975}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SimpleRabbit.NetCore.Tests", "SimpleRabbit.NetCore.Tests\SimpleRabbit.NetCore.Tests.csproj", "{B40D3E11-407C-4422-A112-108891C99682}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -53,6 +55,10 @@ Global
 		{FB1DF967-5993-4E06-8A2C-58815F460975}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FB1DF967-5993-4E06-8A2C-58815F460975}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FB1DF967-5993-4E06-8A2C-58815F460975}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B40D3E11-407C-4422-A112-108891C99682}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B40D3E11-407C-4422-A112-108891C99682}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B40D3E11-407C-4422-A112-108891C99682}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B40D3E11-407C-4422-A112-108891C99682}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SimpleRabbit.NetCore/Model/BasicMessage.cs
+++ b/SimpleRabbit.NetCore/Model/BasicMessage.cs
@@ -13,13 +13,13 @@ namespace SimpleRabbit.NetCore
             DeliveryArgs = deliveryArgs;
             Channel = channel;
             Queue = queue;
-            RegisterError = registerError;
+            ErrorAction = registerError;
         }
 
         public BasicDeliverEventArgs DeliveryArgs { get; }
         public IModel Channel { get; }
         public string Queue { get; }
-        public Action RegisterError { get; }
+        public Action ErrorAction { get; }
 
         public string Body => Encoding.UTF8.GetString(DeliveryArgs?.Body);
         public IBasicProperties Properties => DeliveryArgs?.BasicProperties;

--- a/SimpleRabbit.NetCore/Service/BasicRabbitService.cs
+++ b/SimpleRabbit.NetCore/Service/BasicRabbitService.cs
@@ -84,6 +84,28 @@ namespace SimpleRabbit.NetCore
             }
         }
 
+        public void ClearConnection()
+        {
+            lock (this)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+                try
+                {
+                    _channel?.Dispose();
+                    _channel = null;
+                }
+                finally
+                {
+                    _connection?.Dispose();
+                    _connection = null;
+                }
+
+            }
+        }
+
         public void Close()
         {
             lock (this)
@@ -95,14 +117,7 @@ namespace SimpleRabbit.NetCore
 
                 try
                 {
-                    try
-                    {
-                        _channel?.Dispose();
-                    }
-                    finally
-                    {
-                        _connection?.Dispose();
-                    }
+                    ClearConnection();
                 }
                 finally
                 {

--- a/SimpleRabbit.NetCore/Service/QueueExecutionService.cs
+++ b/SimpleRabbit.NetCore/Service/QueueExecutionService.cs
@@ -77,7 +77,7 @@ namespace SimpleRabbit.NetCore
                 }
                 catch
                 {
-                    queuedMessage.Message.RegisterError?.Invoke();
+                    queuedMessage.Message.ErrorAction?.Invoke();
                     lock (_semaphore)
                     {
                         _queue.Clear();


### PR DESCRIPTION
Adding tests against basic cases using stub classes.
Fixes included
- Nack on Exception was dropping messages, from older copy paste.

Other changes
- Renamed RegisterError to ErrorAction (more semantically clear)