### PR TITLE
Add display name

### DIFF
--- a/SimpleRabbit.NetCore/Model/QueueConfiguration.cs
+++ b/SimpleRabbit.NetCore/Model/QueueConfiguration.cs
@@ -5,6 +5,10 @@
         public string ExchangeName { get; set; }
         public string ConsumerTag { get; set; }
         public string QueueName { get; set; }
+        /// <summary>
+        /// The name to display inside of Rabbit MQ. defauls to ConsumerTag if not specified
+        /// </summary>
+        public string DisplayName { get; set; }
         public ushort? PrefetchCount { get; set; }
         /// <summary>
         /// On error, how long it waits until reattempting to restart consuming

--- a/SimpleRabbit.NetCore/Service/QueueService.cs
+++ b/SimpleRabbit.NetCore/Service/QueueService.cs
@@ -82,7 +82,7 @@ namespace SimpleRabbit.NetCore
                 consumer.Received += ReceiveEvent;
 
                 Channel.BasicQos(0, _queueServiceParams.PrefetchCount ?? 1, false);
-                Channel.BasicConsume(_queueServiceParams.QueueName, false, _queueServiceParams.ConsumerTag, consumer);
+                Channel.BasicConsume(_queueServiceParams.QueueName, false, _queueServiceParams.DisplayName ?? _queueServiceParams.ConsumerTag, consumer);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
This is to abstract consumer tag (internal to application) and the display, so the same application can use the same display name for all queues. 