### PR TITLE
Feature/transient handlers

### DIFF
--- a/Examples/Multi-Subscriber.Service/Program.cs
+++ b/Examples/Multi-Subscriber.Service/Program.cs
@@ -28,7 +28,7 @@ namespace Subscriber.Service
                     {
                         var config = context.Configuration;
                         services
-                            .AddSingleton<IMessageHandler,MessageProcessor>()
+                            .AddSingletonMessageHandler<MessageProcessor>()
                             .AddRabbitConfiguration("name",config.GetSection("RabbitConfiguration"))
                             .AddRabbitConfiguration("name2",config.GetSection("RabbitConfiguration2"))
                             .AddSubscriberConfiguration("name",context.Configuration.GetSection("RabbitConfiguration:Subscribers"))

--- a/Examples/Subscriber.Service/Program.cs
+++ b/Examples/Subscriber.Service/Program.cs
@@ -28,7 +28,7 @@ namespace Subscriber.Service
                     {
                         var config = context.Configuration;
                         services
-                            .AddSingleton<IMessageHandler,MessageProcessor>()
+                            .AddTransientMessageHandler<MessageProcessor>()
                             .AddRabbitConfiguration(config.GetSection("RabbitConfiguration"))
                             .AddSubscriberConfiguration(config.GetSection("Subscribers"))
                             .AddSubscriberServices();

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The corresponding appsettings.json file (to provide connectivity to rabbit):
                     .AddRabbitConfiguration(config.GetSection("RabbitConfiguration"))
                     .AddSubscriberConfiguration(config.GetSection("Subscribers"))
                     .AddSubscriberServices();
-                    .AddSingleton<IMessageHandler,MessageProcessor>()
+                    .AddSingletonMessageHandler<MessageProcessor>()
             });
 
         await builder.RunConsoleAsync();

--- a/RabbitMQ server/Run.bat
+++ b/RabbitMQ server/Run.bat
@@ -1,0 +1,6 @@
+@echo off
+CALL docker build -t myrabbitmq .
+CALL docker run -d --rm --name local-rabbit -p 15672:15672 -p 5672:5672 myrabbitmq
+Echo Hit any key to stop database
+PAUSE >nul
+CALL docker stop local-rabbit

--- a/RabbitMQ server/Run.bat
+++ b/RabbitMQ server/Run.bat
@@ -1,6 +1,6 @@
 @echo off
 CALL docker build -t myrabbitmq .
 CALL docker run -d --rm --name local-rabbit -p 15672:15672 -p 5672:5672 myrabbitmq
-Echo Hit any key to stop database
+Echo Hit any key to stop RMQ server
 PAUSE >nul
 CALL docker stop local-rabbit

--- a/SimpleRabbit.NetCore.Service/ServiceCollectionExtension.cs
+++ b/SimpleRabbit.NetCore.Service/ServiceCollectionExtension.cs
@@ -54,6 +54,31 @@ namespace SimpleRabbit.NetCore.Service
             return services.Configure<List<QueueConfiguration>>(Options.DefaultName, config);
         }
 
+        /// <summary>
+        /// Register a message handler for use with queue factory. This will register it under IMessageHandler.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="services"></param>
+        /// <returns></returns>
+        public static IServiceCollection AddSingletonMessageHandler<T>(this IServiceCollection services) where T : class, IMessageHandler
+        {
+            services.AddSingleton<IMessageHandler, T>();
+            // don't need to register as self, as QueueFactory will use the single instance.
+            return services;
+        }
+
+        /// <summary>
+        /// Register a message handler for use with queue factory. This will register it under IMessageHandler and itself.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="services"></param>
+        /// <returns></returns>
+        public static IServiceCollection AddTransientMessageHandler<T>(this IServiceCollection services) where T : class, IMessageHandler
+        {
+            services.AddTransient<IMessageHandler, T>();
+            services.AddTransient<T>();
+            return services;
+        }
 
     }
 }

--- a/SimpleRabbit.NetCore.Tests/QueueFactoryTests.cs
+++ b/SimpleRabbit.NetCore.Tests/QueueFactoryTests.cs
@@ -127,9 +127,6 @@ namespace SimpleRabbit.NetCore.Tests
 
             firstHandler.Should().NotBeNull();
             secondHandler.Should().NotBeNull();
-
-            firstHandler.Should().NotBeNull();
-            secondHandler.Should().NotBeNull();
             firstHandler.Should().BeSameAs(secondHandler);
         }
     }

--- a/SimpleRabbit.NetCore.Tests/QueueFactoryTests.cs
+++ b/SimpleRabbit.NetCore.Tests/QueueFactoryTests.cs
@@ -1,0 +1,142 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using SimpleRabbit.NetCore.Service;
+using SimpleRabbit.NetCore.Tests.implementations;
+using Subscriber.Service.Service;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SimpleRabbit.NetCore.Tests
+{
+    [TestFixture]
+    public class QueueFactoryTests
+    {
+        [Test]
+
+        public void TransientHandler()
+        {
+            var mockLog = new Mock<ILogger<QueueFactory>>();
+            var subConfig = new Mock<IOptions<List<Subscribers>>>();
+            subConfig
+                .Setup(x => x.Value)
+                .Returns(
+                    new List<Subscribers>() { 
+                        new Subscribers { Name = "first"},
+                        new Subscribers{Name = "second"} 
+                    }
+                );
+            var queueConfig = new Mock<IOptionsMonitor<List<QueueConfiguration>>>();
+            queueConfig
+                .Setup(x=>x.Get(It.IsAny<string>()))
+                .Returns(new List<QueueConfiguration>(){
+                    new QueueConfiguration
+                    {
+                        QueueName = "first",
+                    },
+                    new QueueConfiguration
+                    {
+                        QueueName = "second",
+                    }
+                }
+                );
+
+            var rabbitConfig = new Mock<IOptionsMonitor<RabbitConfiguration>>();
+
+            rabbitConfig.Setup(x => x.Get(It.IsAny<string>()))
+                .Returns(new RabbitConfiguration { Name = "config" });
+
+            var provider = new ServiceCollection()
+               .AddTransientMessageHandler<MessageProcessor>()
+               .BuildServiceProvider();
+
+            var handlers = provider.GetServices<IMessageHandler>();
+
+            var service = new ExposedQueueFactory(mockLog.Object,subConfig.Object,queueConfig.Object,rabbitConfig.Object,provider,handlers);
+
+            service.StartQueues("default");
+
+            var queues = service.Queues;
+
+            var outputHandlers = queues.Values.SelectMany(x => x).Select(x=>(StubQueueService)x).ToList();
+
+            outputHandlers.Count().Should().Be(2, "because only 2 queues are registered");
+
+            var firstHandler = outputHandlers[0].Handler;
+            var secondHandler = outputHandlers[1].Handler;
+
+            firstHandler.Should().NotBeNull();
+            secondHandler.Should().NotBeNull();
+            firstHandler.Should().NotBeSameAs(secondHandler);
+        }
+
+        [Test]
+        public void SingletonHandler()
+        {
+            var mockLog = new Mock<ILogger<QueueFactory>>();
+            var subConfig = new Mock<IOptions<List<Subscribers>>>();
+            subConfig
+                .Setup(x => x.Value)
+                .Returns(
+                    new List<Subscribers>() {
+                        new Subscribers { Name = "first"},
+                        new Subscribers{Name = "second"}
+                    }
+                );
+            var queueConfig = new Mock<IOptionsMonitor<List<QueueConfiguration>>>();
+            queueConfig
+                .Setup(x => x.Get(It.IsAny<string>()))
+                .Returns(new List<QueueConfiguration>(){
+                    new QueueConfiguration
+                    {
+                        QueueName = "first",
+                    },
+                    new QueueConfiguration
+                    {
+                        QueueName = "second",
+                    }
+                }
+                );
+
+            var rabbitConfig = new Mock<IOptionsMonitor<RabbitConfiguration>>();
+
+            rabbitConfig.Setup(x => x.Get(It.IsAny<string>()))
+                .Returns(new RabbitConfiguration { Name = "config" });
+
+            var provider = new ServiceCollection()
+               .AddSingletonMessageHandler<MessageProcessor>()
+               .BuildServiceProvider();
+
+            var handlers = provider.GetServices<IMessageHandler>();
+
+            var service = new ExposedQueueFactory(mockLog.Object, subConfig.Object, queueConfig.Object, rabbitConfig.Object, provider, handlers);
+
+            service.StartQueues("default");
+
+            var queues = service.Queues;
+
+            var outputHandlers = queues.Values.SelectMany(x => x).Select(x => (StubQueueService)x).ToList();
+
+            outputHandlers.Count().Should().Be(2, "because only 2 queues are registered");
+
+            var firstHandler = outputHandlers[0].Handler;
+            var secondHandler = outputHandlers[1].Handler;
+
+            firstHandler.Should().NotBeNull();
+            secondHandler.Should().NotBeNull();
+
+            firstHandler.Should().NotBeNull();
+            secondHandler.Should().NotBeNull();
+            firstHandler.Should().BeSameAs(secondHandler);
+        }
+    }
+
+
+
+
+
+
+}

--- a/SimpleRabbit.NetCore.Tests/SimpleRabbit.NetCore.Tests.csproj
+++ b/SimpleRabbit.NetCore.Tests/SimpleRabbit.NetCore.Tests.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\SimpleRabbit.NetCore.Service\SimpleRabbit.NetCore.Service.csproj" />
     <ProjectReference Include="..\SimpleRabbit.NetCore\SimpleRabbit.NetCore.csproj" />
   </ItemGroup>
 

--- a/SimpleRabbit.NetCore.Tests/implementations/ExposedQueueFactory.cs
+++ b/SimpleRabbit.NetCore.Tests/implementations/ExposedQueueFactory.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using SimpleRabbit.NetCore.Service;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SimpleRabbit.NetCore.Tests.implementations
+{
+    public class ExposedQueueFactory : QueueFactory
+    {
+        public Dictionary<string, List<IQueueService>> Queues { get => _queueServices; }
+        public ExposedQueueFactory(ILogger<QueueFactory> logger, IOptions<List<Subscribers>> subscribers, IOptionsMonitor<List<QueueConfiguration>> queueconfig, IOptionsMonitor<RabbitConfiguration> rabbitconfig, IServiceProvider provider, IEnumerable<IMessageHandler> handlers) : base(logger, subscribers, queueconfig, rabbitconfig, provider, handlers)
+        {
+        }
+
+        public override IQueueService CreateQueue(RabbitConfiguration config)
+        {
+            return new StubQueueService(config);
+        }
+    }
+}

--- a/SimpleRabbit.NetCore.Tests/implementations/StubQueueService.cs
+++ b/SimpleRabbit.NetCore.Tests/implementations/StubQueueService.cs
@@ -1,0 +1,73 @@
+﻿using Microsoft.Extensions.Logging;
+using RabbitMQ.Client;
+
+namespace SimpleRabbit.NetCore.Tests.implementations
+{
+
+    public class StubQueueService : IQueueService
+    {
+
+        public IMessageHandler Handler { get; set; }
+
+        public QueueConfiguration SubscriberConfig { get; set; }
+        public RabbitConfiguration RabbitConfig { get; set; }
+
+        public StubQueueService(RabbitConfiguration config)
+        {
+            RabbitConfig = config;
+        }
+
+        public void Close()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public IBasicProperties GetBasicProperties()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void Start(string queue, string tag, IMessageHandler handler, ushort prefetch = 1)
+        {
+            SubscriberConfig = new QueueConfiguration
+            {
+                PrefetchCount = prefetch,
+                QueueName = queue,
+                ConsumerTag = tag,
+            };
+            Handler = handler;
+        }
+
+        public void Start(QueueConfiguration subscriberConfiguration, IMessageHandler handler)
+        {
+            SubscriberConfig = subscriberConfiguration;
+            Handler = handler;
+        }
+
+        public void Stop()
+        {
+            throw new System.NotImplementedException();
+        }
+
+
+
+        #region IDisposable Support
+        private bool disposedValue = false; // To detect redundant calls
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                }
+                disposedValue = true;
+            }
+        }
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
Add ability to do transient handlers, if the handler has state requirements (memory cache or task queue that may have conflicting keys).

This defaults to singleton (original behaviour). Transient handler is registered using service extension
`services.AddTransientMessageHandler<T>()`.

This is done by registering the MessageProcessor to itself. 

QueueFactory and QueueService are now protected (in order to facilitate tests)