### PR TITLE
fix a bug introduced to QueueService by async message handling refactor

### DIFF
--- a/SimpleRabbit.NetCore/Service/QueueService.cs
+++ b/SimpleRabbit.NetCore/Service/QueueService.cs
@@ -45,6 +45,8 @@ namespace SimpleRabbit.NetCore
                 _timer.Stop();
                 TimerActivation();
             };
+            
+            Factory.DispatchConsumersAsync = true;
         }
 
         public void Start(string queue, string tag, IMessageHandler handler, ushort prefetch = 1)


### PR DESCRIPTION
When IAsyncBasicConsumer is used, the connection should be set to DispatchConsumerAsync = true.

Referece: [https://www.rabbitmq.com/dotnet-api-guide.html#consuming-async](https://www.rabbitmq.com/dotnet-api-guide.html#consuming-async)