### PR TITLE
Fix silent consumer death after broker events and connection recovery

### DIFF
--- a/SimpleRabbit.NetCore/Service/BasicRabbitService.cs
+++ b/SimpleRabbit.NetCore/Service/BasicRabbitService.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Authentication;
 using System.Threading;
+using Microsoft.Extensions.Logging;
 using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
 
 namespace SimpleRabbit.NetCore
 {
@@ -58,25 +60,86 @@ namespace SimpleRabbit.NetCore
             }
         }
         private string ClientName =>
-            _config?.Name ?? 
+            _config?.Name ??
             Environment.GetEnvironmentVariable("COMPUTERNAME") ??
             Environment.GetEnvironmentVariable("HOSTNAME");
 
         private readonly RabbitConfiguration _config;
+        private readonly ILogger _baseLogger;
 
         protected BasicRabbitService(RabbitConfiguration config)
         {
             _config = config;
         }
 
+        protected BasicRabbitService(RabbitConfiguration config, ILogger logger) : this(config)
+        {
+            _baseLogger = logger;
+        }
+
         private IConnection _connection;
         /// <summary>
         /// ClientName is used only for human reference from RabbitMQ UI.
         /// </summary>
-        protected IConnection Connection => _connection ?? (_connection = Factory.CreateConnection(_hostnames, ClientName));
+        protected IConnection Connection
+        {
+            get
+            {
+                if (_connection == null)
+                {
+                    _connection = Factory.CreateConnection(_hostnames, ClientName);
+
+                    if (_connection is IAutorecoveringConnection autorecovering)
+                    {
+                        autorecovering.RecoverySucceeded += OnConnectionRecoverySucceeded;
+                        autorecovering.ConnectionRecoveryError += OnConnectionRecoveryError;
+                    }
+
+                    _connection.ConnectionShutdown += OnConnectionShutdown;
+                }
+
+                return _connection;
+            }
+        }
 
         private IModel _channel;
         protected IModel Channel => _channel ?? (_channel = Connection.CreateModel());
+
+        private void OnConnectionRecoverySucceeded(object sender, EventArgs e)
+        {
+            _baseLogger?.LogInformation("RabbitMQ connection recovered successfully, invalidating channel");
+            lock (_lock)
+            {
+                // Invalidate the stale channel so it gets recreated on next access.
+                // The connection itself is still valid (it just recovered).
+                try
+                {
+                    _channel?.Dispose();
+                }
+                catch
+                {
+                    // Channel may already be disposed after recovery
+                }
+                _channel = null;
+            }
+            OnRecovered();
+        }
+
+        private void OnConnectionRecoveryError(object sender, ConnectionRecoveryErrorEventArgs e)
+        {
+            _baseLogger?.LogError(e.Exception, "RabbitMQ connection recovery failed");
+        }
+
+        private void OnConnectionShutdown(object sender, ShutdownEventArgs e)
+        {
+            _baseLogger?.LogWarning("RabbitMQ connection shutdown: {Reason}", e.ReplyText);
+        }
+
+        /// <summary>
+        /// Called when the connection has been automatically recovered.
+        /// Override to re-register consumers or perform other post-recovery actions.
+        /// </summary>
+        protected virtual void OnRecovered() { }
 
         public IBasicProperties GetBasicProperties()
         {
@@ -102,9 +165,24 @@ namespace SimpleRabbit.NetCore
                 }
                 finally
                 {
-                    _connection?.Close();
-                    _connection?.Dispose();
-                    _connection = null;
+                    try
+                    {
+                        if (_connection != null)
+                        {
+                            if (_connection is IAutorecoveringConnection autorecovering)
+                            {
+                                autorecovering.RecoverySucceeded -= OnConnectionRecoverySucceeded;
+                                autorecovering.ConnectionRecoveryError -= OnConnectionRecoveryError;
+                            }
+                            _connection.ConnectionShutdown -= OnConnectionShutdown;
+                        }
+                    }
+                    finally
+                    {
+                        _connection?.Close();
+                        _connection?.Dispose();
+                        _connection = null;
+                    }
                 }
 
             }

--- a/SimpleRabbit.NetCore/Service/QueueService.cs
+++ b/SimpleRabbit.NetCore/Service/QueueService.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using System.Collections.Concurrent;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SimpleRabbit.NetCore
@@ -21,17 +22,20 @@ namespace SimpleRabbit.NetCore
         private const int DefaultRetryInterval = 15;
 
         private readonly ILogger<QueueService> _logger;
+        private readonly object _restartLock = new object();
 
         private readonly Timer _timer;
         private QueueConfiguration _queueServiceParams;
         private IMessageHandler _handler;
         private TimeSpan RetryInterval => TimeSpan.FromSeconds(_queueServiceParams?.RetryIntervalInSeconds ?? DefaultRetryInterval);
-        
+
         private int _retryCount;
+        private int _restarting;
+        private volatile bool _stopping;
 
         private ConcurrentBag<ulong> _toBeNackedMessages = new ConcurrentBag<ulong>();
 
-        public QueueService(RabbitConfiguration options, ILogger<QueueService> logger) : base(options)
+        public QueueService(RabbitConfiguration options, ILogger<QueueService> logger) : base(options, logger)
         {
             _logger = logger;
 
@@ -71,6 +75,7 @@ namespace SimpleRabbit.NetCore
         private void Start()
         {
             Stop();
+            _stopping = false;
             if (_handler == null)
             {
                 throw new ArgumentNullException(nameof(_handler), $"No handler provided for {_queueServiceParams.ConsumerTag} => {_queueServiceParams.QueueName}");
@@ -80,14 +85,48 @@ namespace SimpleRabbit.NetCore
             {
                 var consumer = new AsyncEventingBasicConsumer(Channel);
                 consumer.Received += ReceiveEventAsync;
+                consumer.ConsumerCancelled += OnConsumerCancelled;
+                consumer.Shutdown += OnConsumerShutdown;
 
                 Channel.BasicQos(0, _queueServiceParams.PrefetchCount ?? 1, false);
                 Channel.BasicConsume(_queueServiceParams.QueueName, false, _queueServiceParams.DisplayName ?? _queueServiceParams.ConsumerTag, consumer);
+
+                _logger.LogInformation($"Consumer started on queue {_queueServiceParams.QueueName}");
             }
             catch (Exception e)
             {
                 _logger.LogError(e, $"{_queueServiceParams.QueueName} -> {e.Message}");
                 RestartIn(RetryInterval);
+            }
+        }
+
+        private Task OnConsumerCancelled(object sender, ConsumerEventArgs e)
+        {
+            if (_stopping) return Task.CompletedTask;
+            _logger.LogWarning($"Consumer cancelled by broker on queue {_queueServiceParams.QueueName}, tags: {string.Join(", ", e.ConsumerTags)}. Scheduling restart.");
+            RestartIn(RetryInterval);
+            return Task.CompletedTask;
+        }
+
+        private Task OnConsumerShutdown(object sender, ShutdownEventArgs e)
+        {
+            if (_stopping) return Task.CompletedTask;
+            _logger.LogWarning($"Consumer shutdown on queue {_queueServiceParams.QueueName}: {e.ReplyText}. Scheduling restart.");
+            RestartIn(RetryInterval);
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Called by BasicRabbitService when the connection has been automatically recovered.
+        /// Re-registers the consumer since the old channel/consumer is stale after recovery.
+        /// </summary>
+        protected override void OnRecovered()
+        {
+            if (_stopping) return;
+            _logger.LogInformation($"Connection recovered, restarting consumer on queue {_queueServiceParams?.QueueName}");
+            if (_queueServiceParams != null && _handler != null)
+            {
+                RestartIn(TimeSpan.FromSeconds(1));
             }
         }
 
@@ -158,7 +197,17 @@ namespace SimpleRabbit.NetCore
                     default:
                     {
                         RestartIn(RetryInterval);
-                        channel.BasicNack(message.DeliveryTag, false, true);
+                        try
+                        {
+                            if (!channel.IsClosed)
+                            {
+                                channel.BasicNack(message.DeliveryTag, false, true);
+                            }
+                        }
+                        catch (Exception nackEx)
+                        {
+                            _logger.LogWarning(nackEx, $"Failed to nack message {message.DeliveryTag} on queue {_queueServiceParams.QueueName} (channel may be closed)");
+                        }
                         return;
                     }
                 }
@@ -172,50 +221,71 @@ namespace SimpleRabbit.NetCore
 
         private void RestartIn(TimeSpan waitInterval)
         {
-            if (_timer.Enabled)
+            // Use atomic compare-exchange to ensure only one thread enters the restart path.
+            if (Interlocked.CompareExchange(ref _restarting, 1, 0) != 0)
             {
-                // another message has already triggered an error.
+                // Another thread is already handling the restart.
                 return;
-                
             }
 
-            if (_queueServiceParams.OnErrorAction == QueueConfiguration.ErrorAction.RestartConnection)
+            try
             {
-                try
+                if (_queueServiceParams.OnErrorAction == QueueConfiguration.ErrorAction.RestartConnection)
                 {
-                    //take note of blocking if clearing connection here
-                    //https://github.com/rabbitmq/rabbitmq-dotnet-client/issues/341
-                    // attempt to stop the event consumption.
-                    if (Channel != null && !Channel.IsClosed)
-                        Channel?.BasicCancel(_queueServiceParams.ConsumerTag);
+                    try
+                    {
+                        //take note of blocking if clearing connection here
+                        //https://github.com/rabbitmq/rabbitmq-dotnet-client/issues/341
+                        // attempt to stop the event consumption.
+                        if (Channel != null && !Channel.IsClosed)
+                            Channel?.BasicCancel(_queueServiceParams.DisplayName ?? _queueServiceParams.ConsumerTag);
+                    }
+                    catch
+                    {
+                        // ignored
+                    }
                 }
-                catch
-                {
-                    // ignored
-                }
+
+                _retryCount++;
+                var interval = waitInterval.TotalSeconds * (_queueServiceParams.AutoBackOff ? _retryCount : 1) % MaxRetryInterval;
+
+                _timer.Interval = interval * 1000; // seconds
+                _logger.LogInformation($" -> restarting in {interval} seconds ({_retryCount}).");
+                _timer.Start();
             }
-
-            _retryCount++;
-            var interval = waitInterval.TotalSeconds * (_queueServiceParams.AutoBackOff ? _retryCount : 1) % MaxRetryInterval;
-
-            _timer.Interval = interval * 1000; // seconds
-            _logger.LogInformation($" -> restarting in {interval} seconds ({_retryCount}).");
-            _timer.Start();
+            catch (Exception e)
+            {
+                _logger.LogError(e, $"Error scheduling restart for queue {_queueServiceParams.QueueName}");
+                // Reset the flag so a future attempt can try again
+                Interlocked.Exchange(ref _restarting, 0);
+            }
         }
 
         private void TimerActivation()
         {
+            // Reset the restart flag so future errors can schedule a new restart.
+            Interlocked.Exchange(ref _restarting, 0);
+
             switch (_queueServiceParams.OnErrorAction)
             {
                 case QueueConfiguration.ErrorAction.NackOnException:
                 {
-                    foreach (var message in _toBeNackedMessages)
+                    try
                     {
-                        if (Channel != null && !Channel.IsClosed)
+                        foreach (var message in _toBeNackedMessages)
                         {
-                            Channel.BasicNack(message, false, true);
+                            if (Channel != null && !Channel.IsClosed)
+                            {
+                                Channel.BasicNack(message, false, true);
+                            }
                         }
-                        
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.LogWarning(e, $"Failed to nack queued messages on {_queueServiceParams.QueueName}, scheduling restart");
+                        _toBeNackedMessages.Clear();
+                        RestartIn(RetryInterval);
+                        return;
                     }
                     _toBeNackedMessages.Clear();
                     return;
@@ -231,7 +301,16 @@ namespace SimpleRabbit.NetCore
 
         public void Stop()
         {
+            _stopping = true;
+            Interlocked.Exchange(ref _restarting, 0);
+            _timer.Stop();
             Close();
+        }
+
+        protected override void Cleanup()
+        {
+            _timer?.Stop();
+            _timer?.Dispose();
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes an issue where consumers silently stop receiving messages from RabbitMQ after a random period (hours to days), requiring a service restart to recover.

Root cause appears to be a combination of bugs in the consumer lifecycle:

- **No `ConsumerCancelled`/`Shutdown` handlers** - when the broker cancels a consumer (HA failover, queue policy change, memory alarm), the consumer goes deaf with zero errors logged
- **Stale channel after connection recovery** - `AutomaticRecoveryEnabled` recovers the connection, but the cached `_channel` field still points to the old dead channel. No `RecoverySucceeded` handler existed to invalidate it
- **Race condition in `RestartIn()`** - the `_timer.Enabled` guard was not atomic, allowing concurrent threads to either both enter or both skip the restart path
- **Unhandled exception in error path** - `BasicNack` after a channel close threw an exception that was caught by the outer handler, which called `RestartIn()` again, but the timer was already running so the second call was a no-op. The consumer never restarted
- **`_stopping` guard on event handlers** - `ConsumerCancelled`/`Shutdown` events also fire during intentional `Stop()`/`Dispose()`, which would schedule an unwanted restart. A volatile flag distinguishes intentional teardown from broker-initiated disconnects

All fixes are internal to `BasicRabbitService` and `QueueService`. No changes to public interfaces, method signatures, configuration models, or enum values.

## Test plan

- [x] Verify full solution builds with no new errors
- [x] Run existing test suite - 41/46 pass, same 5 pre-existing test isolation failures as original code (All tests pass individually; failures are caused by shared queue state between tests in the same run)
- [x] Integration test: kill the RabbitMQ connection mid-consume and verify the consumer recovers automatically 
  - **Tested, killed the RabbitMQ connection via management API mid-consume and confirmed the consumer detected the drop, recovered, and resumed processing messages automatically, see screenshot:**
  <img width="1031" height="982" alt="image" src="https://github.com/user-attachments/assets/f37ff352-df17-48e6-9da9-850e9002f8e6" />
- [x] Integration test: delete and recreate the queue while a consumer is active and verify it restarts
  - **Tested using example Subscriber.Service locally, deleted MyQueue locally got:** `Consumer cancelled by broker on queue MyQueue, tags: Subscriber. Scheduling restart.`
  - **Recreated queue, got:** `Consumer started on queue MyQueue`
- [x] Verify PublishService still works (uses original single-arg base constructor)
  - **The PublishWithExchange, PublishWithProperties, PublishDirect, PublishEmptyMessage, PublishWithException and ToExchange tests all use PublishService and they all passed in our test run.**
